### PR TITLE
fix: metro and watchman config

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,1 +1,5 @@
-{}
+{
+  "fsevents_latency": 0.05,
+  "fsevents_try_resync": "true",
+  "prefer_split_fsevents_watcher": "true"
+}

--- a/metro.config.js
+++ b/metro.config.js
@@ -8,6 +8,8 @@ const blacklist = require('metro-config/src/defaults/exclusionList');
 require('dotenv').config();
 
 module.exports = {
+  resetCache: true,
+  stickyWorkers: false,
   transformer: {
     getTransformOptions: async () => ({
       transform: {
@@ -37,4 +39,9 @@ module.exports = {
     // process.env.PROVIDER_WEB3_UTILS,
     // process.env.PROVIDER_LEDGER_RN_PACKAGE,
   ].filter(Boolean),
+  watcher: {
+    healthCheck: {
+      enabled: true
+    }
+  }
 };


### PR DESCRIPTION
Fixes #

Previously app had a bug with `watchman` and `metro bundler`.
`watchman` sended `Recrawled this watch 47 times, most recently because:
MustScanSubDirs UserDroppedTo resolve, please review the information on
https://facebook.github.io/watchman/docs/troubleshooting.html#recrawl`

And `metro bundler` provoked "file freeze" behavior. 

## Proposed Changes

  -
  -
  -

## Checklist

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
