### PR TITLE
refactor: remove .watchmanconfig

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,7 +1,0 @@
-{
-  "fsevents_latency": 0.05,
-  "fsevents_try_resync": "true",
-  "prefer_split_fsevents_watcher": "true",
-  "ignore_dirs": ["Pods", ".git"],
-  "idle_reap_age_seconds": 600
-}


### PR DESCRIPTION
Fixes #

## Proposed Changes

- removed `.watchmanconfig` to solve this problem with Watchman.

```bash
Error: A non-recoverable condition has triggered.  Watchman needs your help!
The triggering condition was at timestamp=1695275631: opendir(/Users/igroza/dev/projects/@haqq/haqq-wallet/node_modules/escape-string-regexp) -> Too many open files
All requests will continue to fail with this message until you resolve
the underlying problem.  You will find more information on fixing this at
https://facebook.github.io/watchman/docs/troubleshooting.html#poison-opendir

    at ChildProcess.<anonymous> (/Users/igroza/dev/projects/@haqq/haqq-wallet/node_modules/fb-watchman/index.js:212:21)
    at ChildProcess.emit (node:events:513:28)
    at maybeClose (node:internal/child_process:1100:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:304:5)
Emitted 'error' event on WatchmanWatcher instance at:
    at Client.<anonymous> (/Users/igroza/dev/projects/@haqq/haqq-wallet/node_modules/metro-file-map/src/watchers/WatchmanWatcher.js:107:12)
    at Client.emit (node:events:513:28)
    at ChildProcess.<anonymous> (/Users/igroza/dev/projects/@haqq/haqq-wallet/node_modules/fb-watchman/index.js:219:12)
    at ChildProcess.emit (node:events:513:28)
    at maybeClose (node:internal/child_process:1100:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:304:5) {
  watchmanResponse: {
    version: '2023.08.14.00',
    error: 'A non-recoverable condition has triggered.  Watchman needs your help!\n' +
      'The triggering condition was at timestamp=1695275631: opendir(/Users/igroza/dev/projects/@haqq/haqq-wallet/node_modules/escape-string-regexp) -> Too many open files\n' +
      'All requests will continue to fail with this message until you resolve\n' +
      'the underlying problem.  You will find more information on fixing this at\n' +
      'https://facebook.github.io/watchman/docs/troubleshooting.html#poison-opendir\n'
  }
}
error: script "start" exited with code 1 (SIGHUP)
```

## Checklist

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
