### PR TITLE
refactor: Move StakingMetadata from realm to mobx

### DIFF
--- a/src/event-actions/on-wallets-staking-balance-check.ts
+++ b/src/event-actions/on-wallets-staking-balance-check.ts
@@ -11,7 +11,7 @@ export async function onWalletsStakingBalanceCheck() {
     const balances = Wallet.getAllVisible().map(w => {
       const metadata = StakingMetadata.getAllByDelegator(
         w.cosmosAddress,
-      ).filtered('type != $0', StakingMetadataType.reward);
+      ).filter(({type}) => type !== StakingMetadataType.reward);
       const total = metadata.reduce(
         (prev, curr) => prev.operate(curr.amountHex, 'add'),
         Balance.Empty,

--- a/src/helpers/staking.ts
+++ b/src/helpers/staking.ts
@@ -15,9 +15,3 @@ export function formatStakingDate(date?: string) {
     {days: String(days)},
   );
 }
-
-export function sumReduce(
-  stakingData: (StakingMetadata & Realm.Object<unknown, never>)[],
-) {
-  return stakingData.reduce((acc, val) => acc + val.amount, 0);
-}

--- a/src/hooks/use-staking-reward.ts
+++ b/src/hooks/use-staking-reward.ts
@@ -2,6 +2,8 @@ import {useEffect, useState} from 'react';
 
 import {autorun} from 'mobx';
 
+import {app} from '@app/contexts';
+import {Events} from '@app/events';
 import {reduceAmounts} from '@app/helpers/staking';
 import {
   StakingMetadata,
@@ -18,13 +20,17 @@ export function useStakingReward() {
   useEffect(() => {
     const rewards = StakingMetadata.getAllByType(StakingMetadataType.reward);
 
-    const disposer = autorun(() => {
+    const listener = () => {
       const rewardsSum = new Balance(reduceAmounts(rewards));
       setRewardAmount(rewardsSum);
-    });
+    };
+
+    const disposer = autorun(listener);
+    app.addListener(Events.onBalanceSync, listener);
 
     return () => {
       disposer();
+      app.removeListener(Events.onBalanceSync, listener);
     };
   }, []);
 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -9,7 +9,6 @@ import {
   WalletRealmObject,
 } from '@app/models/realm-object-for-migration';
 import {Refferal} from '@app/models/refferal';
-import {StakingMetadata} from '@app/models/staking-metadata';
 import {UserSchema, UserType} from '@app/models/user';
 import {VariablesBool} from '@app/models/variables-bool';
 import {VariablesDate} from '@app/models/variables-date';
@@ -42,7 +41,6 @@ export const realm = new Realm({
     TransactionRealmObject,
     ContactRealmObject,
     Provider,
-    StakingMetadata,
     Refferal,
     NftCollection,
     News,

--- a/src/screens/HomeStack/HomeEarnStack/home-earn.tsx
+++ b/src/screens/HomeStack/HomeEarnStack/home-earn.tsx
@@ -66,7 +66,7 @@ export const HomeEarnScreen = observer(() => {
       StakingMetadataType.undelegation,
     );
 
-    const disposer = autorun(() => {
+    const listener = () => {
       const rewardsSum = reduceAmounts(rewards);
       const stakingSum = reduceAmounts(delegations);
       const unDelegationSum = reduceAmounts(unDelegations);
@@ -82,10 +82,14 @@ export const HomeEarnScreen = observer(() => {
         availableSum,
         loading: false,
       });
-    });
+    };
+
+    const disposer = autorun(listener);
+    app.addListener(Events.onBalanceSync, listener);
 
     return () => {
       disposer();
+      app.removeListener(Events.onBalanceSync, listener);
     };
   }, [visible]);
 

--- a/src/screens/HomeStack/HomeEarnStack/staking-info.tsx
+++ b/src/screens/HomeStack/HomeEarnStack/staking-info.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
+import {autorun} from 'mobx';
 import {observer} from 'mobx-react';
 
 import {StakingInfo} from '@app/components/staking-info';
@@ -56,11 +57,9 @@ export const StakingInfoScreen = observer(() => {
   }, [rewards]);
 
   useEffect(() => {
-    const r = StakingMetadata.getAllByValidator(operator_address);
+    const data = StakingMetadata.getAllByValidator(operator_address);
 
-    const subscription = () => {
-      const data = r.snapshot();
-
+    const disposer = autorun(() => {
       setRewards(data.filter(row => row.type === StakingMetadataType.reward));
       setDelegated(
         data.filter(row => row.type === StakingMetadataType.delegation),
@@ -68,11 +67,10 @@ export const StakingInfoScreen = observer(() => {
       setUndelegated(
         data.filter(row => row.type === StakingMetadataType.undelegation),
       );
-    };
+    });
 
-    r.addListener(subscription);
     return () => {
-      r.removeListener(subscription);
+      disposer();
     };
   }, [operator_address]);
 
@@ -186,7 +184,10 @@ export const StakingInfoScreen = observer(() => {
 
   const onUnDelegate = useCallback(async () => {
     const delegations = new Set(
-      StakingMetadata.getDelegationsForValidator(operator_address)
+      StakingMetadata.getAllByTypeForValidator(
+        operator_address,
+        StakingMetadataType.delegation,
+      )
         .filter(v => v.amount >= minAmount.toFloat())
         .map(v => v.delegator),
     );

--- a/src/screens/HomeStack/HomeEarnStack/staking-validators.tsx
+++ b/src/screens/HomeStack/HomeEarnStack/staking-validators.tsx
@@ -1,6 +1,8 @@
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
 import {Validator} from '@evmos/provider/dist/rest/staking';
+import {autorun} from 'mobx';
+import {observer} from 'mobx-react';
 
 import {
   StakingValidators,
@@ -18,7 +20,7 @@ import {
 import {HomeEarnStackParamList, HomeEarnStackRoutes} from '@app/route-types';
 import {AdjustEvents, ValidatorItem} from '@app/types';
 
-export const StakingValidatorsScreen = () => {
+export const StakingValidatorsScreen = observer(() => {
   const navigation = useTypedNavigation<HomeEarnStackParamList>();
   const cosmos = useCosmos();
 
@@ -31,9 +33,10 @@ export const StakingValidatorsScreen = () => {
     onTrackEvent(AdjustEvents.stakingValidators);
   }, []);
 
-  const onCache = useCallback(() => {
-    const cache = StakingMetadata.getAll().reduce<Record<string, any>>(
-      (memo, row) => {
+  useEffect(() => {
+    const rows = StakingMetadata.getAll();
+    const disposer = autorun(() => {
+      const cache = rows.reduce<Record<string, any>>((memo, row) => {
         const value = memo[row.validator] || {
           [StakingMetadataType.delegation]: 0,
           [StakingMetadataType.undelegation]: 0,
@@ -46,27 +49,20 @@ export const StakingValidatorsScreen = () => {
         };
 
         return memo;
-      },
-      {},
-    );
-    const keys = Object.keys(cache);
-    if (
-      keys.length !== Object.keys(stakingCache).length ||
-      keys.find(key => !stakingCache[key])
-    ) {
-      setStakingCache(cache);
-    }
-  }, [stakingCache]);
+      }, {});
+      const keys = Object.keys(cache);
+      if (
+        keys.length !== Object.keys(stakingCache).length ||
+        keys.find(key => !stakingCache[key])
+      ) {
+        setStakingCache(cache);
+      }
+    });
 
-  useEffect(() => {
-    const rows = StakingMetadata.getAll();
-    rows.addListener(onCache);
-
-    onCache();
     return () => {
-      rows.removeListener(onCache);
+      disposer();
     };
-  }, [onCache]);
+  }, [stakingCache]);
 
   useEffect(() => {
     cosmos.getAllValidators(1000).then(validatorsList => {
@@ -164,4 +160,4 @@ export const StakingValidatorsScreen = () => {
       onPress={onPressValidator}
     />
   );
-};
+});

--- a/src/screens/HomeStack/StakingUndelegateStack/staking-undelegate-form.tsx
+++ b/src/screens/HomeStack/StakingUndelegateStack/staking-undelegate-form.tsx
@@ -8,7 +8,10 @@ import {StakingUnDelegateForm} from '@app/components/staking-undelegate-form';
 import {getProviderInstanceForWallet} from '@app/helpers';
 import {useCosmos, useTypedNavigation, useTypedRoute} from '@app/hooks';
 import {useLayoutEffectAsync} from '@app/hooks/use-effect-async';
-import {StakingMetadata} from '@app/models/staking-metadata';
+import {
+  StakingMetadata,
+  StakingMetadataType,
+} from '@app/models/staking-metadata';
 import {Wallet} from '@app/models/wallet';
 import {
   StakingUnDelegateStackParamList,
@@ -36,8 +39,10 @@ export const StakingUnDelegateFormScreen = observer(() => {
   );
 
   const balance = useMemo(() => {
-    const delegations =
-      StakingMetadata.getDelegationsForValidator(operator_address);
+    const delegations = StakingMetadata.getAllByTypeForValidator(
+      operator_address,
+      StakingMetadataType.delegation,
+    );
 
     const delegation = delegations.find(
       d => d.delegator === wallet?.cosmosAddress,


### PR DESCRIPTION
## Proposed Changes
- Move from realm to mobx
- Store metadata in object instead of array for faster write/read

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
