### PR TITLE
feat: fetch web3 browser bookmark from remote config

### DIFF
--- a/src/components/browser-edit-bookmarks.tsx
+++ b/src/components/browser-edit-bookmarks.tsx
@@ -8,8 +8,8 @@ import DraggableFlatList, {
 } from 'react-native-draggable-flatlist';
 
 import {Color} from '@app/colors';
+import {useRemoteConfigVar} from '@app/hooks/use-remote-config';
 import {I18N} from '@app/i18n';
-import {STRICT_URLS} from '@app/screens/HomeStack/BrowserStack/browser-home-page-screen';
 import {Link} from '@app/types';
 
 import {LinkPreview, LinkPreviewVariant} from './link-preview';
@@ -34,6 +34,8 @@ export const BrowserEditBookmarks = ({
   onPressBack,
   onPressSubmit,
 }: BrowserEditBookmarksProps) => {
+  const web3BrowserBookmarks = useRemoteConfigVar('web3_browser_bookmarks');
+
   const renderItem = useCallback(
     ({item, drag, isActive}: RenderItemParams<Link>) => {
       if (!item?.id) {
@@ -44,7 +46,9 @@ export const BrowserEditBookmarks = ({
         onPressRemove?.(item);
       };
 
-      const isStrictUrl = !!STRICT_URLS.find(link => item.url === link.url);
+      const isStrictUrl = !!web3BrowserBookmarks.find(
+        link => item.url === link.url,
+      );
 
       return (
         <ScaleDecorator activeScale={1.05}>
@@ -76,7 +80,7 @@ export const BrowserEditBookmarks = ({
         </ScaleDecorator>
       );
     },
-    [onPressRemove],
+    [onPressRemove, web3BrowserBookmarks],
   );
 
   const keyExtractor = useCallback((item: Link) => item.id, []);

--- a/src/hooks/use-remote-config.ts
+++ b/src/hooks/use-remote-config.ts
@@ -6,8 +6,14 @@ export function useRemoteConfigVar<K extends keyof RemoteConfigTypes>(key: K) {
   const [variable, setVariable] = useState(RemoteConfig.get(key));
 
   useEffect(() => {
+    // get from cache if config in not initialized
     setVariable(RemoteConfig.get(key));
+
+    // update value when config is initialized
+    RemoteConfig.awaitForInitialization().then(() => {
+      setVariable(RemoteConfig.get(key));
+    });
   }, [key]);
 
-  return variable as RemoteConfigTypes[K] | undefined;
+  return variable as RemoteConfigTypes[K];
 }

--- a/src/screens/HomeStack/BrowserStack/browser-home-page-screen.tsx
+++ b/src/screens/HomeStack/BrowserStack/browser-home-page-screen.tsx
@@ -13,25 +13,10 @@ import {
   BrowserStackParamList,
   BrowserStackRoutes,
 } from '@app/screens/HomeStack/BrowserStack';
+import {RemoteConfig} from '@app/services/remote-config';
 import {AdjustEvents, Link} from '@app/types';
 
-export const STRICT_URLS: Partial<Link>[] = [
-  {
-    title: 'HAQQ Dashboard',
-    url: 'https://shell.haqq.network',
-    icon: 'https://haqq.network/assets/media-kit/haqq-sign.svg',
-  },
-  {
-    title: 'HAQQ Vesting',
-    url: 'https://vesting.haqq.network',
-    icon: 'https://vesting.haqq.network/assets/favicon.svg',
-  },
-  {
-    title: 'SushiSwap',
-    url: 'https://www.sushi.com/swap',
-    icon: 'https://raw.githubusercontent.com/sushiswap/sushiswap/master/apps/evm/public/icon-512x512.svg',
-  },
-];
+export const STRICT_URLS: Partial<Link>[] = [];
 
 export const BrowserHomePageScreen = memo(() => {
   const navigation = useTypedNavigation<BrowserStackParamList>();
@@ -71,10 +56,13 @@ export const BrowserHomePageScreen = memo(() => {
   }, [navigation]);
 
   useEffect(() => {
-    STRICT_URLS.forEach(link => {
-      if (!Web3BrowserBookmark.getByUrl(link?.url || '')) {
-        Web3BrowserBookmark.create(link);
-      }
+    RemoteConfig.awaitForInitialization().then(() => {
+      const web3BrowserBookmarks = RemoteConfig.get('web3_browser_bookmarks')!;
+      web3BrowserBookmarks.forEach(link => {
+        if (!Web3BrowserBookmark.getByUrl(link?.url || '')) {
+          Web3BrowserBookmark.create(link);
+        }
+      });
     });
   }, []);
 

--- a/src/services/remote-config/remote-config-default-values.ts
+++ b/src/services/remote-config/remote-config-default-values.ts
@@ -111,4 +111,21 @@ export const REMOTE_CONFIG_DEFAULT_VALUES: Required<RemoteConfigTypes> = {
   staking_reward_min_amount: getDefaultBalanceValue(
     'staking_reward_min_amount',
   ).toHex(),
+  web3_browser_bookmarks: [
+    {
+      title: 'HAQQ Dashboard',
+      url: 'https://shell.haqq.network',
+      icon: 'https://haqq.network/assets/media-kit/haqq-sign.png',
+    },
+    {
+      title: 'HAQQ Vesting',
+      url: 'https://vesting.haqq.network',
+      icon: 'https://vesting.haqq.network/assets/favicon.svg',
+    },
+    {
+      title: 'SushiSwap',
+      url: 'https://www.sushi.com/swap',
+      icon: 'https://raw.githubusercontent.com/sushiswap/sushiswap/master/apps/evm/public/icon-512x512.svg',
+    },
+  ],
 };

--- a/src/services/remote-config/remote-config-service.ts
+++ b/src/services/remote-config/remote-config-service.ts
@@ -19,7 +19,10 @@ const logger = Logger.create('RemoteConfig', {
 function getCachedConfig() {
   const cacheString = VariablesString.get(KEY);
   if (isValidJSON(cacheString)) {
-    return JSON.parse(cacheString) as RemoteConfigTypes;
+    return {
+      ...REMOTE_CONFIG_DEFAULT_VALUES,
+      ...JSON.parse(cacheString),
+    } as RemoteConfigTypes;
   }
   return REMOTE_CONFIG_DEFAULT_VALUES;
 }

--- a/src/services/remote-config/remote-config-types.ts
+++ b/src/services/remote-config/remote-config-types.ts
@@ -1,6 +1,6 @@
 import {SessionTypes} from '@walletconnect/types';
 
-import {RootStackParamList} from '@app/types';
+import {Link, RootStackParamList} from '@app/types';
 
 export type WalletConnectNamespace = Omit<SessionTypes.Namespace, 'accounts'>;
 
@@ -37,4 +37,5 @@ export interface RemoteConfigTypes extends RemoteConfigBalanceTypes {
   pattern_source: string;
   sss_generate_shares_url: string;
   sss_metadata_url: string;
+  web3_browser_bookmarks: Omit<Link, 'subtitle' | 'id'>[];
 }


### PR DESCRIPTION
Fixes #

## Proposed Changes

HQM-284

- fetch web3 browser bookmark from remote config

variable name: `web3_browser_bookmarks`

```TS
Array<{
  url: string;
  title: string;
  icon?: string;
}>
```

## Checklist

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
