### PR TITLE
fix: Hide close button on banners when close event equals none

### DIFF
--- a/src/widgets/ad-widget/index.tsx
+++ b/src/widgets/ad-widget/index.tsx
@@ -25,6 +25,7 @@ import {ShadowCard} from '@app/components/ui/shadow-card';
 import {onDeepLink} from '@app/event-actions/on-deep-link';
 import {onTrackEvent} from '@app/event-actions/on-track-event';
 import {getWindowDimensions} from '@app/helpers';
+import {BannerButtonEvent} from '@app/models/banner';
 import {IAdWidget} from '@app/types';
 import {openWeb3Browser} from '@app/utils';
 import {GRADIENT_END, GRADIENT_START} from '@app/variables/common';
@@ -40,6 +41,11 @@ export const AdWidget = ({banner, style}: HomeBannerProps) => {
   const widthRef = useRef(0);
   const [isSmall, setIsSmall] = useState(false);
   const window = getWindowDimensions();
+
+  const showCloseButton = useMemo(
+    () => banner.closeEvent && banner.closeEvent !== BannerButtonEvent.none,
+    [banner],
+  );
 
   const onPressClose = useCallback(async () => {
     setVisible(false);
@@ -138,7 +144,7 @@ export const AdWidget = ({banner, style}: HomeBannerProps) => {
             </Inline>
           </>
         )}
-        {banner.closeEvent && (
+        {showCloseButton && (
           <IconButton style={styles.closeButton} onPress={onPressClose}>
             <Icon
               name="close_circle"

--- a/src/widgets/banner-widget/index.tsx
+++ b/src/widgets/banner-widget/index.tsx
@@ -17,6 +17,7 @@ import {
 import {ShadowCard} from '@app/components/ui/shadow-card';
 import {onDeepLink} from '@app/event-actions/on-deep-link';
 import {onTrackEvent} from '@app/event-actions/on-track-event';
+import {BannerButtonEvent} from '@app/models/banner';
 import {IBannerWidget} from '@app/types';
 import {openWeb3Browser} from '@app/utils';
 import {GRADIENT_END, GRADIENT_START} from '@app/variables/common';
@@ -29,6 +30,11 @@ export interface HomeBannerProps {
 export const BannerWidget = ({banner, style}: HomeBannerProps) => {
   const [loading, setLoading] = useState(false);
   const [isVisible, setVisible] = useState(true);
+
+  const showCloseButton = useMemo(
+    () => banner.closeEvent && banner.closeEvent !== BannerButtonEvent.none,
+    [banner],
+  );
 
   const onPressClose = useCallback(async () => {
     setVisible(false);
@@ -114,7 +120,7 @@ export const BannerWidget = ({banner, style}: HomeBannerProps) => {
             ))}
           </Inline>
         )}
-        {banner.closeEvent && (
+        {showCloseButton && (
           <IconButton style={styles.closeButton} onPress={onPressClose}>
             <Icon
               name="close_circle"


### PR DESCRIPTION
Fixes #

## Proposed Changes

-
-
-

## Checklist

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
