### PR TITLE
feat(HAM-326): Add support for remote commission multipliers setup

### DIFF
--- a/src/helpers/get-remote-balance-value.tsx
+++ b/src/helpers/get-remote-balance-value.tsx
@@ -4,6 +4,7 @@ import {
   RemoteConfigBalanceTypes,
 } from '@app/services/remote-config';
 import {
+  BALANCE_MULTIPLIER,
   COSMOS_MIN_AMOUNT,
   COSMOS_MIN_GAS_LIMIT,
   MIN_AMOUNT,
@@ -25,12 +26,16 @@ export const getDefaultBalanceValue = <
       return COSMOS_MIN_AMOUNT;
     case 'cosmos_min_gas_limit':
       return COSMOS_MIN_GAS_LIMIT;
+    case 'cosmos_commission_multiplier':
+      return BALANCE_MULTIPLIER;
     case 'eth_min_amount':
       return MIN_AMOUNT;
     case 'eth_min_gas_limit':
       return MIN_GAS_LIMIT;
+    case 'eth_commission_multiplier':
+      return BALANCE_MULTIPLIER;
     default:
-      return MIN_AMOUNT;
+      return Balance.Empty;
   }
 };
 
@@ -43,10 +48,5 @@ export const getRemoteBalanceValue = <T extends keyof RemoteConfigBalanceTypes>(
     return new Balance(remoteValue);
   }
 
-  const defaultValue = getDefaultBalanceValue(key);
-
-  if (!defaultValue) {
-    return Balance.Empty;
-  }
-  return defaultValue;
+  return getDefaultBalanceValue(key);
 };

--- a/src/services/cosmos.ts
+++ b/src/services/cosmos.ts
@@ -401,11 +401,12 @@ export class Cosmos {
         };
       }
 
-      const gas = new Balance(
-        parseInt(resp.gas_info.gas_used, 10) *
+      const gas = new Balance(parseInt(resp.gas_info.gas_used, 10))
+        .operate(
           getRemoteBalanceValue('cosmos_commission_multiplier').toNumber(),
-        0,
-      ).max(baseGas);
+          'mul',
+        )
+        .max(baseGas);
 
       const amount = baseFee.operate(gas, 'mul').max(totalAmount);
       return {

--- a/src/services/cosmos.ts
+++ b/src/services/cosmos.ts
@@ -402,7 +402,8 @@ export class Cosmos {
       }
 
       const gas = new Balance(
-        parseInt(resp.gas_info.gas_used, 10) * 1.35,
+        parseInt(resp.gas_info.gas_used, 10) *
+          getRemoteBalanceValue('cosmos_commission_multiplier').toNumber(),
         0,
       ).max(baseGas);
 

--- a/src/services/eth-network.ts
+++ b/src/services/eth-network.ts
@@ -165,10 +165,9 @@ export class EthNetwork {
         maxPriorityFeePerGas: gasPrice.toHex(),
       } as Deferrable<TransactionRequest>);
 
-      estimateGas = new Balance(
-        estGas.toNumber() *
-          getRemoteBalanceValue('eth_commission_multiplier').toNumber(),
-      ).max(minGas);
+      estimateGas = new Balance(estGas.toNumber())
+        .operate(getRemoteBalanceValue('eth_commission_multiplier'), 'mul')
+        .max(minGas);
     } catch {
       //
     }

--- a/src/services/eth-network.ts
+++ b/src/services/eth-network.ts
@@ -165,7 +165,10 @@ export class EthNetwork {
         maxPriorityFeePerGas: gasPrice.toHex(),
       } as Deferrable<TransactionRequest>);
 
-      estimateGas = new Balance(estGas._hex).max(minGas);
+      estimateGas = new Balance(
+        estGas.toNumber() *
+          getRemoteBalanceValue('eth_commission_multiplier').toNumber(),
+      ).max(minGas);
     } catch {
       //
     }

--- a/src/services/remote-config/remote-config-default-values.ts
+++ b/src/services/remote-config/remote-config-default-values.ts
@@ -107,8 +107,14 @@ export const REMOTE_CONFIG_DEFAULT_VALUES: Required<RemoteConfigTypes> = {
   version: 1,
   cosmos_min_amount: getDefaultBalanceValue('cosmos_min_amount').toHex(),
   cosmos_min_gas_limit: getDefaultBalanceValue('cosmos_min_gas_limit').toHex(),
+  cosmos_commission_multiplier: getDefaultBalanceValue(
+    'cosmos_commission_multiplier',
+  ).toHex(),
   eth_min_amount: getDefaultBalanceValue('eth_min_amount').toHex(),
   eth_min_gas_limit: getDefaultBalanceValue('eth_min_gas_limit').toHex(),
+  eth_commission_multiplier: getDefaultBalanceValue(
+    'eth_commission_multiplier',
+  ).toHex(),
   transfer_min_amount: getDefaultBalanceValue('transfer_min_amount').toHex(),
   staking_reward_min_amount: getDefaultBalanceValue(
     'staking_reward_min_amount',

--- a/src/services/remote-config/remote-config-types.ts
+++ b/src/services/remote-config/remote-config-types.ts
@@ -12,8 +12,10 @@ export type WalletConnectAllowedNamespaces = Record<
 export interface RemoteConfigBalanceTypes {
   cosmos_min_amount: string;
   cosmos_min_gas_limit: string;
+  cosmos_commission_multiplier: string;
   eth_min_amount: string;
   eth_min_gas_limit: string;
+  eth_commission_multiplier: string;
   transfer_min_amount: string;
   staking_reward_min_amount: string;
 }


### PR DESCRIPTION
Fixes #

## Proposed Changes

- [HQM-326](https://linear.app/haqq/issue/HQM-326/use-commission-multipliers-from-remote-config)

## Checklist

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
