### PR TITLE
chore: update react-native-webview from version 13.6.0 to 13.8.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -585,7 +585,8 @@ PODS:
     - react-native-video/Video (= 5.2.1)
   - react-native-video/Video (5.2.1):
     - React-Core
-  - react-native-webview (13.6.0):
+  - react-native-webview (13.8.1):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - React-NativeModulesApple (0.72.4):
     - hermes-engine
@@ -1108,7 +1109,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Adjust: 41d0d5c031409aebe7fb1f5703ff0d3306133439
   AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
-  boost: 0a937fbcfdd646fca221c4f1d9750d7ccfdfc2dc
+  boost: 57d2868c099736d80fcd648bf211b4431e51a558
   BVLinearGradient: fbe308a1d19a8133f69e033abc85d8008644f5e3
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CryptoSwift: c4f2debceb38bf44c80659afe009f71e23e4a082
@@ -1187,7 +1188,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 9697629f7b2cda43cf52169bb7e0767d330648c2
   react-native-splash-screen: 4312f786b13a81b5169ef346d76d33bc0c6dc457
   react-native-video: c26780b224543c62d5e1b2a7244a5cd1b50e8253
-  react-native-webview: 669ae162965f629a8d6a4bdd3b99a304d36ef1f2
+  react-native-webview: bdc091de8cf7f8397653e30182efcd9f772e03b3
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
   React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00

--- a/ios/haqq.xcodeproj/project.pbxproj
+++ b/ios/haqq.xcodeproj/project.pbxproj
@@ -163,7 +163,7 @@
 		CCE74304A95D3744DEB0803A /* libPods-haqq-haqqTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7064F852C87C11A84661A18D /* libPods-haqq-haqqTests.a */; };
 		CEB60C4A517B4A0E9FC525A3 /* cloud-problems@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 5CCF10400ADB4F63AB8CAC62 /* cloud-problems@3x.png */; };
 		CEBA4969BB874AF6B924DA37 /* domain-blocked-dark@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = F5FCD1005E8E4C08BB4782E3 /* domain-blocked-dark@3x.png */; };
-		CF0D49E2FABD41D9A34AB04C /* (null) in Resources */ = {isa = PBXBuildFile; };
+		CF0D49E2FABD41D9A34AB04C /* BuildFile in Resources */ = {isa = PBXBuildFile; };
 		CF3BD3A1F0A24224948734D3 /* ElMessiri-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6B48442C371E4A5CB312ED9E /* ElMessiri-Medium.ttf */; };
 		CF474CA50EB643EB87EA09A4 /* cloud-share-not-found@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 477AFBB25A0D45F18299CC7F /* cloud-share-not-found@3x.png */; };
 		CF6F3ED1E5A54155A2507F94 /* ledger-locked@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 60F20D8762B94A298A8895E3 /* ledger-locked@3x.png */; };
@@ -870,7 +870,7 @@
 				BEFF23B4E9FE4A40BD7E5624 /* SF-ProText-Regular.ttf in Resources */,
 				F57AEFB435FF4249932EF918 /* SF-ProText-Semibold.ttf in Resources */,
 				2129B78329CACF69005C0CCA /* overview.storyboard in Resources */,
-				CF0D49E2FABD41D9A34AB04C /* (null) in Resources */,
+				CF0D49E2FABD41D9A34AB04C /* BuildFile in Resources */,
 				1A6D4E352A149298001B1549 /* staking_on_earn_page_dark.riv in Resources */,
 				7CE3C371577D43A6BAA1DF94 /* backup-notification-dark.png in Resources */,
 				8EF155B29CA4479AA8E82E4A /* backup-notification-dark@2x.png in Resources */,

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "react-native-toast-message": "2.2.0",
     "react-native-touch-id": "4.4.1",
     "react-native-video": "5.2.1",
-    "react-native-webview": "13.6.0",
+    "react-native-webview": "13.8.1",
     "react-timer-mixin": "0.13.4",
     "readable-stream": "4.4.2",
     "realm": "11.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10424,7 +10424,7 @@ __metadata:
     react-native-toast-message: 2.2.0
     react-native-touch-id: 4.4.1
     react-native-video: 5.2.1
-    react-native-webview: 13.6.0
+    react-native-webview: 13.8.1
     react-test-renderer: 18.2.0
     react-timer-mixin: 0.13.4
     readable-stream: 4.4.2
@@ -16212,16 +16212,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-webview@npm:13.6.0":
-  version: 13.6.0
-  resolution: "react-native-webview@npm:13.6.0"
+"react-native-webview@npm:13.8.1":
+  version: 13.8.1
+  resolution: "react-native-webview@npm:13.8.1"
   dependencies:
     escape-string-regexp: 2.0.0
     invariant: 2.2.4
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: f7220fb18dcf5e9631674831ac8beb3bc4b99863f812676c25394a3cce487975b05c8fc795b0ee4ff1ead43da304ddea104f5e6683ea3f4c3a135b14ae193069
+  checksum: 1760405dcd601c4f5a6e8b9f35f7eaf8e4107a47861037f4f73a7e39a3a6d10824fd76a04454266ff99e40742aedbf02aacca4b548b5744c96d22ebcacc97f04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

- update react-native-webview from version 13.6.0 to 13.8.1

## Checklist

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
