### PR TITLE
fix(HQM-370): do not show WalletConnect toasts if wc connection is not established

### DIFF
--- a/src/services/wallet-connect.ts
+++ b/src/services/wallet-connect.ts
@@ -132,12 +132,18 @@ export class WalletConnect extends Initializable {
       this._core.relayer.on('relayer_connect', async () => {
         // connection to the relay server is established
         logger.log('🟢 relayer_connect');
-        sendNotification(I18N.walletConnectConnectionEstablished);
+        const haveActiveSessions = !!this.getActiveSessions()?.length;
+        if (haveActiveSessions) {
+          sendNotification(I18N.walletConnectConnectionEstablished);
+        }
       });
       this._core.relayer.on('relayer_disconnect', async () => {
         // connection to the relay server is lost
         logger.log('🔴 relayer_disconnect');
-        sendNotification(I18N.walletConnectConnectionLost);
+        const haveActiveSessions = !!this.getActiveSessions()?.length;
+        if (haveActiveSessions) {
+          sendNotification(I18N.walletConnectConnectionLost);
+        }
       });
 
       // this event called when user disconect from web site


### PR DESCRIPTION
Fixes #

## Proposed Changes

- HQM-370: do not show WalletConnect toasts if wc connection is not established

## Checklist

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
