### PR TITLE
feat: sentry screenshoot only for fatal events

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,12 @@ if (Config.SENTRY_DSN && DEBUG_VARS.enableSentry) {
       enableWatchdogTerminationTracking: false,
       attachScreenshot: true,
       attachStacktrace: true,
-      attachViewHierarchy: true,
+      beforeSend(event, hint){
+        if(event.level !== 'fatal') {
+          delete hint.attachments;
+        }
+        return event;
+      }
     });
   } catch (e) {
     console.log('sentry init failed');

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -11,13 +11,7 @@ interface LoggerOptions {
 
 const BG_GREEN_TEXT_WHITE_BOLD = __DEV__ ? '\x1b[42m\x1b[37m\x1b[1m' : '';
 const RESET = __DEV__ ? '\x1b[0m' : '';
-const ALLOWED_TAGS_PRIMITIVE_TYPES = [
-  'number',
-  'string',
-  'boolean',
-  'bigint',
-  'symbol',
-];
+const POSSIBLE_ERROR_ID_KEYS = ['id', 'errorid', 'error_id'];
 export class LoggerService {
   private _enabled?: boolean;
   private _stringifyJson?: boolean;
@@ -89,12 +83,14 @@ export class LoggerService {
         scope.clear();
         scope.setTag('source', source);
         scope.setTag('tag', this._tag);
+        scope.setExtras(context);
 
         Object.entries(context).forEach(([key, value]) => {
-          if (ALLOWED_TAGS_PRIMITIVE_TYPES.includes(typeof value)) {
-            const k = key === 'id' || key === 'errorId' ? 'error_id' : key;
-            scope.setTag(k, value);
-          } else if (Array.isArray(value)) {
+          if (POSSIBLE_ERROR_ID_KEYS.includes(key.toLowerCase())) {
+            scope.setTag('error_id', value);
+          }
+
+          if (Array.isArray(value)) {
             scope.setContext(key, {value});
           } else {
             scope.setContext(key, value);


### PR DESCRIPTION
Fixes #

## Proposed Changes

- sentry ScreenShoot only for fatal events

## Checklist

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
