### PR TITLE
fix: EthereumMessageChecker allow spaces

### DIFF
--- a/src/helpers/ethereum-message-checker.ts
+++ b/src/helpers/ethereum-message-checker.ts
@@ -104,7 +104,10 @@ export class EthereumMessageChecker {
     msg: string,
   ): EthereumSignInMessage | null {
     try {
-      const parts = msg.split('\n').filter(p => p?.trim().length > 0);
+      const parts = msg
+        .split('\n')
+        .map(p => p?.trim())
+        .filter(p => p?.length > 0);
       const [message, address, statement, ...keyValues] = parts;
 
       if (!message || !address || !statement || keyValues?.length === 0) {


### PR DESCRIPTION
Fixes #

## Proposed Changes

- EthereumMessageChecker allow spaces

## Checklist

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
