### PR TITLE
feat: adb script for input pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "git:action:restart": "git pull && git commit --amend -n --no-edit && git push -f",
     "env:verify": "yarn zx ./scripts/verify-env.mjs",
     "env:update": "yarn zx ./scripts/update-version.mjs",
-    "locales:update": "yarn zx ./scripts/pull-locales.mjs"
+    "locales:update": "yarn zx ./scripts/pull-locales.mjs",
+    "pin": "sh ./scripts/adb-enter-pin.sh"
   },
   "dependencies": {
     "@birdwingo/react-native-spinning-numbers": "1.0.5",

--- a/scripts/adb-enter-pin.sh
+++ b/scripts/adb-enter-pin.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Function to display help message
+show_help() {
+  echo
+  echo "Usage: $0 <6-digit PIN code>"
+  echo
+  echo "This script sends a 6-digit PIN code as keyboard input to all connected ADB devices."
+  echo
+  echo "Options:"
+  echo "  ${BOLD}-h, --help${NC}    Show this help message and exit"
+}
+
+# Colors for log messages
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+# Check for help option
+if [[ $1 == "-h" || $1 == "--help" ]]; then
+  show_help
+  exit 0
+fi
+
+# Check if PIN code is provided
+if [ $# -ne 1 ]; then
+  echo "${RED}Error: Please provide a 6-digit PIN code.${NC}"
+  show_help
+  exit 1
+fi
+
+pin_code=$1
+
+# Check if PIN code is 6 digits
+if [[ ! "$pin_code" =~ ^[0-9]{6}$ ]]; then
+  echo "${RED}Error: PIN code must be 6 digits.${NC}"
+  show_help
+  exit 1
+fi
+
+# Get the list of connected devices and store in an array
+devices=($(adb devices | grep -w "device" | cut -f1))
+
+# Check if there are any connected devices
+if [ ${#devices[@]} -eq 0 ]; then
+  echo "${RED}No connected devices found.${NC}"
+  exit 1
+fi
+
+echo "${GREEN}Connected devices:${NC}"
+for device in "${devices[@]}"; do
+  echo " - ${BLUE}${BOLD}$device${NC}"
+done
+echo ""
+
+# Send the PIN code to each connected device
+for device in "${devices[@]}"; do
+  echo "${GREEN}Sending PIN code to device: ${BLUE}${BOLD}$device${NC}"
+  for (( i=0; i<=${#pin_code}; i++ )); do
+    digit=${pin_code:$i:1}
+    adb -s "$device" shell input press numeric_keyboard_"$digit"
+  done
+  sleep 1
+done
+
+echo ""
+echo "🎉 ${GREEN}${BOLD}PIN code successfully sent to all devices.${NC}"


### PR DESCRIPTION
Fixes #

## Proposed 

- Added a shell script `adb-enter-pin.sh` to send a 6-digit PIN code as keyboard input to all connected ADB devices.
- Added support for `-h` and `--help` options in the shell script to display usage information.
- Updated package.json to include a new script `yarn pin <6-DIGIT-PIN>` to run the shell script with Yarn.

<img width="920" alt="image" src="https://github.com/haqq-network/haqq-wallet/assets/25716589/1d67f5a8-5eb5-49ca-8f00-1ae8402a60b6">


https://github.com/haqq-network/haqq-wallet/assets/25716589/59a065b6-a5ec-4823-af73-eff317813848



## Checklist

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
