### PR TITLE
feat: show banner link when dev mode enabled

### DIFF
--- a/src/widgets/ad-widget/index.tsx
+++ b/src/widgets/ad-widget/index.tsx
@@ -1,6 +1,8 @@
 import React, {useCallback, useMemo, useRef, useState} from 'react';
 
+import Clipboard from '@react-native-clipboard/clipboard';
 import {
+  Alert,
   I18nManager,
   Image,
   LayoutChangeEvent,
@@ -24,6 +26,7 @@ import {
   TextPosition,
 } from '@app/components/ui';
 import {ShadowCard} from '@app/components/ui/shadow-card';
+import {app} from '@app/contexts';
 import {onDeepLink} from '@app/event-actions/on-deep-link';
 import {getWindowDimensions} from '@app/helpers';
 import {BannerButtonEvent} from '@app/models/banner';
@@ -68,6 +71,22 @@ export const AdWidget = ({banner, style}: HomeBannerProps) => {
     const link = banner.target;
     if (!link) {
       return;
+    }
+    if (app.isTesterMode) {
+      Alert.alert(
+        'Banner link',
+        `${link}\n\n You see this message because you are in developer mode.`,
+        [
+          {
+            text: 'Copy',
+            onPress: () => Clipboard.setString(link),
+          },
+          {
+            text: 'Cancel',
+            style: 'cancel',
+          },
+        ],
+      );
     }
     if (link.startsWith('haqq:')) {
       const isHandled = onDeepLink(link);

--- a/src/widgets/banner-widget/index.tsx
+++ b/src/widgets/banner-widget/index.tsx
@@ -1,6 +1,8 @@
 import React, {useCallback, useMemo, useState} from 'react';
 
+import Clipboard from '@react-native-clipboard/clipboard';
 import {
+  Alert,
   I18nManager,
   Image,
   StyleProp,
@@ -22,6 +24,7 @@ import {
   Text,
 } from '@app/components/ui';
 import {ShadowCard} from '@app/components/ui/shadow-card';
+import {app} from '@app/contexts';
 import {openURL} from '@app/helpers/url';
 import {BannerButtonEvent} from '@app/models/banner';
 import {EventTracker} from '@app/services/event-tracker';
@@ -61,6 +64,22 @@ export const BannerWidget = ({banner, style}: HomeBannerProps) => {
     const link = banner.target;
     if (!link) {
       return;
+    }
+    if (app.isTesterMode) {
+      Alert.alert(
+        'Ad banner link',
+        `${link}\n\n You see this message because you are in developer mode.`,
+        [
+          {
+            text: 'Copy',
+            onPress: () => Clipboard.setString(link),
+          },
+          {
+            text: 'Cancel',
+            style: 'cancel',
+          },
+        ],
+      );
     }
     openURL(link);
     setLoading(false);


### PR DESCRIPTION
Fixes #

## Proposed Changes

- show banner link when dev mode enabled

![telegram-cloud-photo-size-2-5370879504869875932-x](https://github.com/user-attachments/assets/5dda2327-4398-4827-af66-1b7209bc8aa4)


## Checklist

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
