### PR TITLE
chore: run patch_build only on main branch

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -79,3 +79,4 @@ jobs:
     secrets: inherit
     needs:
       - slack_notify
+    if: ${{ github.event.inputs.BRANCH == 'main' || inputs.BRANCH == 'main' }}


### PR DESCRIPTION
Fixes #

## Proposed Changes

- run patch_build only on main branch

## Checklist

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
