### PR TITLE
chore: implement devpkg module resolver

### DIFF
--- a/.devpkg.js
+++ b/.devpkg.js
@@ -1,0 +1,55 @@
+const path = require('path');
+const fs = require('fs');
+const config = require('./.devpkg.json');
+
+const extraNodeModules = {};
+const watchFolders = [];
+const nodeModulesPaths = [];
+
+if (config.enabled) {
+  Object.entries(config.packages).forEach(([pkgName, pkgConfig]) => {
+    const pkgPath = pkgConfig.path;
+    const useDevEntryPoint = pkgConfig.useDevEntryPoint ?? false;
+    const packageJsonPath = path.resolve(pkgPath, 'package.json');
+    const packageJson = require(packageJsonPath);
+
+    let entryPoint = '';
+    if (useDevEntryPoint && packageJson.devEntryPoint) {
+      entryPoint = packageJson.devEntryPoint;
+    } else if (packageJson.main) {
+      entryPoint = packageJson.main;
+    }
+
+    if (entryPoint) {
+      const fullEntryPath = path.resolve(__dirname, pkgPath, entryPoint);
+      if (fs.existsSync(fullEntryPath)) {
+        extraNodeModules[pkgName] = fullEntryPath;
+        const resolvedPkgPath = path.resolve(__dirname, pkgPath);
+        watchFolders.push(resolvedPkgPath);
+        nodeModulesPaths.push(resolvedPkgPath);
+
+        console.log(
+          '\x1b[32m%s\x1b[0m',
+          `✅ [devpkg] ${pkgName} -> ${extraNodeModules[pkgName]}`,
+        );
+        console.log('\x1b[34m%s\x1b[0m', `📝 ${packageJson.description}`);
+      } else {
+        console.error(
+          '\x1b[31m%s\x1b[0m',
+          `❌ [devpkg] Entry point not found for ${pkgName}: ${fullEntryPath}`,
+        );
+      }
+    } else {
+      console.error(
+        '\x1b[31m%s\x1b[0m',
+        `❌ [devpkg] No entry point specified for ${pkgName}`,
+      );
+    }
+  });
+}
+
+module.exports = {
+  extraNodeModules,
+  watchFolders,
+  nodeModulesPaths,
+};

--- a/.devpkg.json
+++ b/.devpkg.json
@@ -1,0 +1,9 @@
+{
+  "enabled": false,
+  "packages": {
+    "@haqq/rn-wallet-providers": {
+      "path": "../haqq-rn-wallet-providers",
+      "useDevEntryPoint": true
+    }
+  }
+}

--- a/.devpkg.md
+++ b/.devpkg.md
@@ -1,0 +1,34 @@
+# DevPkg Documentation
+
+## Overview
+
+The DevPkg feature allows developers to override npm packages with local development versions. This is particularly useful when working on multiple interconnected packages simultaneously, enabling real-time testing and debugging of changes across projects.
+
+## How It Works
+
+DevPkg modifies the Metro bundler configuration to prioritize specified local package directories over the versions installed in `node_modules`. This allows you to use development versions of packages without publishing them to npm or manually linking them.
+
+## Configuration
+
+### .devpkg.json
+
+This file contains the configuration for DevPkg. Here's an example structure:
+
+```json
+{
+  "enabled": true,
+  "packages": {
+    "your-local-package": {
+      "path": "/path/to/your/local/package",
+      "useDevEntryPoint": true
+    }
+  }
+}
+```
+
+### Explanation
+
+- `enabled`: Enables or disables the package overriding.
+- `packages`: A list of packages to override with local development versions.
+- `path`: The path to the local package directory.
+- `useDevEntryPoint`: If true, uses the `devEntryPoint` specified in the package.json of the local package. Otherwise, uses the `main` field.

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,3 +1,9 @@
+# if devpkg is enabled, throw error and exit with code 1
+if [ -f .devpkg.json ] && [ "$(jq -r '.enabled' .devpkg.json)" = "true" ]; then
+  echo "\033[31mError: DevPkg is enabled. Please disable .devpkg.json to proceed with commit.\033[0m" >&2
+  exit 1
+fi
+
 #!/bin/sh
 npx patch-package --error-on-fail
 

--- a/metro.config.js
+++ b/metro.config.js
@@ -3,6 +3,9 @@ const path = require('path');
 const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
 const blacklist = require('metro-config/src/defaults/exclusionList');
 
+// used for local development
+const devpkg = require('./.devpkg.js');
+
 const defaultModuleResolver =
   getDefaultConfig(__dirname).resolver.resolveRequest;
 
@@ -20,18 +23,26 @@ const config = {
     // plugins: ['@babel/plugin-proposal-numeric-separator'],
   },
   resolver: {
-    extraNodeModules: require('node-libs-react-native'),
+    extraNodeModules: {
+      ...require('node-libs-react-native'),
+      ...devpkg.extraNodeModules,
+    },
     blacklistRE: blacklist([
       /ios\/build\/SourcePackages\/checkouts\/grpc-ios\/native_src\/.*/,
     ]),
     nodeModulesPaths: [
-      // process.env.PROVIDER_BASE_PACKAGE,
-      // process.env.PROVIDER_HOT_PACKAGE,
-      // process.env.ENCRYPTION_RN_PACKAGE,
-      // process.env.PROVIDER_WEB3_UTILS,
-      // process.env.PROVIDER_LEDGER_RN_PACKAGE,
+     ...devpkg.nodeModulesPaths,
     ].filter(Boolean),
     resolveRequest: (context, moduleName, platform) => {
+      try {
+       if(devpkg.extraNodeModules[moduleName]) {
+        return {
+          filePath: devpkg.extraNodeModules[moduleName],
+          type: 'sourceFile',
+        };
+       }
+      } catch (error) {}
+
       try {
         return context.resolveRequest(context, moduleName, platform);
       } catch (error) {
@@ -84,11 +95,7 @@ const config = {
     },
   },
   watchFolders: [
-    // process.env.PROVIDER_BASE_PACKAGE,
-    // process.env.PROVIDER_HOT_PACKAGE,
-    // process.env.ENCRYPTION_RN_PACKAGE,
-    // process.env.PROVIDER_WEB3_UTILS,
-    // process.env.PROVIDER_LEDGER_RN_PACKAGE,
+    ...devpkg.watchFolders,
   ].filter(Boolean),
   watcher: {
     healthCheck: {


### PR DESCRIPTION
# DevPkg Documentation

## Overview

The DevPkg feature allows developers to override npm packages with local development versions. This is particularly useful when working on multiple interconnected packages simultaneously, enabling real-time testing and debugging of changes across projects.

## How It Works

DevPkg modifies the Metro bundler configuration to prioritize specified local package directories over the versions installed in `node_modules`. This allows you to use development versions of packages without publishing them to npm or manually linking them.

## Configuration

### .devpkg.json

This file contains the configuration for DevPkg. Here's an example structure:

```json
{
  "enabled": true,
  "packages": {
    "your-local-package": {
      "path": "/path/to/your/local/package",
      "useDevEntryPoint": true
    }
  }
}
```

### Explanation

- `enabled`: Enables or disables the package overriding.
- `packages`: A list of packages to override with local development versions.
- `path`: The path to the local package directory.
- `useDevEntryPoint`: If true, uses the `devEntryPoint` specified in the package.json of the local package. Otherwise, uses the `main` field.

## Checklist

- [x] I have read the rules of [**contribution**](https://github.com/haqq-network/haqq-wallet/blob/main/docs/contribution.md#important-steps).
